### PR TITLE
respect language cookie on switchContext()

### DIFF
--- a/core/components/smartrouting/src/Plugins/Events/OnHandleRequest.php
+++ b/core/components/smartrouting/src/Plugins/Events/OnHandleRequest.php
@@ -132,6 +132,7 @@ class OnHandleRequest extends Plugin
         $cultureKey = $this->modx->getOption('cultureKey', null, 'en');
         $cultureKey = $this->modx->getOption('cultureKey', $_SESSION, $cultureKey, true);
         $cultureKey = $this->modx->getOption('cultureKey', $_REQUEST, $cultureKey, true);
+        $cultureKey = $this->modx->getOption('cultureKey', $_COOKIE, $cultureKey, true);
         $this->modx->cultureKey = $cultureKey;
         $this->modx->setOption('cultureKey', $cultureKey);
 


### PR DESCRIPTION
Hi @Jako, thanks for SmartRouting. I replaced XRouting in a project with it and it works great.

I set a cookie called `cultureKey` before the SmartRouting plugin (onHandleRequest) to change the lexicon language based on user preference.

This PR works great in my project. Hopefully we can merge it? 