### PR TITLE
Add error_page to required context settings

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,7 +15,7 @@ list to route multiple domains to one context.
 ## Instructions
 
 All you need to do is to install this plugin and make sure your contexts have
-`http_host`, `base_url`, `site_url`, `site_start` and optional
+`http_host`, `base_url`, `site_url`, `site_start`, `error_page` and optional
 `http_host_aliases` context settings set.
 
 To easily edit these context settings side by side, you can use the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,8 +15,8 @@ list to route multiple domains to one context.
 ## Instructions
 
 All you need to do is to install this plugin and make sure your contexts have
-`http_host`, `base_url`, `site_url`, `site_start`, `error_page` and optional
-`http_host_aliases` context settings set.
+`http_host`, `base_url`, `site_url`, `site_start`, `error_page` and optional 
+`http_host_aliases` and `unauthorized_page` context settings set.
 
 To easily edit these context settings side by side, you can use the
 [CrossContextsSettings](https://modx.com/extras/package/crosscontextssettings)


### PR DESCRIPTION
Adding an `error_page` prevents a possible 500 exhaustion error, so I recommend treating it like a required field.  